### PR TITLE
Add possibility to mount extra secret files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
+FROM openjdk:8-jdk-alpine as builder
+COPY . /
+RUN ./mvnw clean verify
+
 FROM openjdk:8-jdk-alpine
 VOLUME /tmp
-ADD target/tesk-0.0.1-SNAPSHOT.jar app.jar
+ADD target/tesk-0.0.1-SNAPSHOT.jar app.jar --from=builder
 #ADD ./config config
 #ENV KUBECONFIG="/config"
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ The meaning of environment variables:
  `TESK_API_TASKMASTER_FILER_IMAGE_VERSION` | Version of filer image, passed on as a parameter to taskmaster. Taskmaster will create Inputs/Outputs filer using the image in this version. If omitted, should default to latest stable version.
  `TESK_API_K8S_NAMESPACE` | K8s namespace, where all the Job objects will be created. If omitted, defaults to `default`.
  `TESK_API_TASKMASTER_FTP_SECRET_NAME` | Name of K8s secret storing credentials to a single FTP account. FTP account is used to demonstrate uploading output files to external storage. If ENV variable is set, FTP username and password will be included by API as taskmaster ENV variables. Otherwise (TESK_API_TASKMASTER_FTP_SECRET_NAME env variable not set), TESK should still work, but without the ability to upload files to a private FTP server.
+ `TESK_API_TASKMASTER_SECRET_VOLUME_NAME` | Name of K8s secret storing extra secret files. If ENV variable is not set, the secrets will not be mounted
+ `TESK_API_TASKMASTER_SECRET_MOUNT_POINT` | Mount point into the job's container of the secret `TESK_API_TASKMASTER_SECRET_VOLUME_NAME`. By default is `/secret`
  `SPRING_PROFILES_ACTIVE` | (default) `noauth` - authN/Z switched off. `auth` - authN/Z switched on.
  `TESK_API_AUTHORISATION_*` | A set of env variables configuring authorisation using Elixir group membership
  `TESK_API_SWAGGER_OAUTH_*` | A set of env variables configuring OAuth2/OIDC client built in Swagger UI

--- a/src/main/java/uk/ac/ebi/tsc/tesk/config/KubernetesObjectsSupplier.java
+++ b/src/main/java/uk/ac/ebi/tsc/tesk/config/KubernetesObjectsSupplier.java
@@ -84,6 +84,22 @@ public class KubernetesObjectsSupplier {
                     });
 
             toBeRemoved.stream().forEach(containerEnvironment::remove);
+
+            final String secretVolumeName = taskmasterEnvProperties.getSecretVolumeName();
+            // TODO Should make this in a more JAVA-way, probably
+            if (secretVolumeName != null) {
+                job.getSpec().getTemplate().getSpec().getVolumes().add(new V1Volume()
+                    .secret(new V1SecretVolumeSource().secretName(secretVolumeName))
+                    .name(secretVolumeName));
+
+                String secretMountPoint = (taskmasterEnvProperties.getSecretMountPoint() != null ?
+                    taskmasterEnvProperties.getSecretMountPoint(): "/secret");
+
+                job.getSpec().getTemplate().getSpec().getContainers()
+                    .get(0).getVolumeMounts().add(new V1VolumeMount()
+                    .mountPath(secretMountPoint).name(secretVolumeName));
+            }
+
             return job;
         } catch (IOException ex) {
             throw new RuntimeException(ex);

--- a/src/main/java/uk/ac/ebi/tsc/tesk/config/TaskmasterEnvProperties.java
+++ b/src/main/java/uk/ac/ebi/tsc/tesk/config/TaskmasterEnvProperties.java
@@ -34,6 +34,18 @@ public class TaskmasterEnvProperties {
     private Ftp ftp;
 
     /**
+     * Volume name to store the extra secret files
+     */
+    private String secretVolumeName;
+
+    /**
+     * Mount point to put the secret volume
+     * Default: /secret
+     */
+    private String secretMountPoint;
+
+
+    /**
      * Service Account name for taskmaster
      */
     private String serviceAccountName;
@@ -57,6 +69,22 @@ public class TaskmasterEnvProperties {
 
     public void setFtp(Ftp ftp) {
         this.ftp = ftp;
+    }
+
+    public String getSecretVolumeName() {
+        return secretVolumeName;
+    }
+
+    public void setSecretVolumeName(final String secretVolumeName) {
+        this.secretVolumeName = secretVolumeName;
+    }
+
+    public String getSecretMountPoint() {
+        return secretMountPoint;
+    }
+
+    public void setSecretMountPoint(final String secretMountPoint) {
+        this.secretMountPoint = secretMountPoint;
     }
 
     public String getImageName() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,6 +24,7 @@ tesk.api.taskmaster.filer-image-version=v0.4
 tesk.api.taskmaster.ftp.secret-name=
 tesk.api.taskmaster.service-account-name=default
 tesk.api.taskmaster.debug=false
+tesk.api.taskmaster.secret-volume-name=podinfo
 
 spring.profiles.active=noauth
 #group authorisation settings

--- a/src/test/java/uk/ac/ebi/tsc/tesk/util/component/TesKubernetesConverterMinimalTest.java
+++ b/src/test/java/uk/ac/ebi/tsc/tesk/util/component/TesKubernetesConverterMinimalTest.java
@@ -57,7 +57,9 @@ import static uk.ac.ebi.tsc.tesk.util.constant.Constants.LABEL_TASKSTATE_VALUE_C
         properties = {"tesk.api.taskmaster.image-name = task-minimal-image-name",
                 "tesk.api.taskmaster.image-version = task-minimal-image-version",
                 "tesk.api.taskmaster.filer-image-version = task-minimal-filer-image-version",
-                "tesk.api.k8s.namespace = test-namespace"})
+                "tesk.api.k8s.namespace = test-namespace",
+                "tesk.api.taskmaster.secret-volume-name = secreto",
+                "tesk.api.taskmaster.secret-mount-point = /secret"})
 @EnableConfigurationProperties(TaskmasterEnvProperties.class)
 public class TesKubernetesConverterMinimalTest {
 

--- a/src/test/java/uk/ac/ebi/tsc/tesk/util/component/TesKubernetesConverterTest.java
+++ b/src/test/java/uk/ac/ebi/tsc/tesk/util/component/TesKubernetesConverterTest.java
@@ -57,7 +57,9 @@ import static uk.ac.ebi.tsc.tesk.util.constant.Constants.LABEL_TASKSTATE_VALUE_C
                 "tesk.api.taskmaster.service-account-name = custom-service-account",
                 "tesk.api.taskmaster.debug = true",
                 "tesk.api.taskmaster.environment.wes.base.path = /usr/sth/path",
-                "tesk.api.taskmaster.environment.TES_BASE_PATH = /tesk/share"
+                "tesk.api.taskmaster.environment.TES_BASE_PATH = /tesk/share",
+                "tesk.api.taskmaster.secret-volume-name = secreto",
+                "tesk.api.taskmaster.secret-mount-point = /secret"
         })
 @EnableConfigurationProperties(TaskmasterEnvProperties.class)
 public class TesKubernetesConverterTest {

--- a/src/test/resources/fromTesToK8s/job.json
+++ b/src/test/resources/fromTesToK8s/job.json
@@ -69,6 +69,10 @@
                 "name": "podinfo",
                 "mountPath": "/podinfo",
                 "readOnly": true
+              },
+              {
+                "name": "secreto",
+                "mountPath": "/secret"
               }
             ],
             "image": "task-full-image-name:task-full-image-version",
@@ -88,6 +92,12 @@
                   }
                 }
               ]
+            }
+          },
+          {
+            "name": "secreto",
+            "secret": {
+              "secretName": "secreto"
             }
           }
         ],

--- a/src/test/resources/fromTesToK8s_minimal/job.json
+++ b/src/test/resources/fromTesToK8s_minimal/job.json
@@ -37,6 +37,10 @@
                 "name": "podinfo",
                 "mountPath": "/podinfo",
                 "readOnly": true
+              },
+              {
+                "name": "secreto",
+                "mountPath": "/secret"
               }
             ]
           }
@@ -53,6 +57,12 @@
                   }
                 }
               ]
+            }
+          },
+          {
+            "name": "secreto",
+            "secret": {
+              "secretName": "secreto"
             }
           }
         ],


### PR DESCRIPTION
To allow mount of extra secret files in the jobs it adds:
* TESK_API_TASKMASTER_SECRET_VOLUME_NAME
* TESK_API_TASKMASTER_SECRET_MOUNT_POINT 

We need this to sign/encrypt files with `crypt4gh` and upload the result using `sftp`.

