### PR TITLE
Elixir groups

### DIFF
--- a/src/integration-test/java/uk/ac/ebi/tsc/tesk/AuthIT.java
+++ b/src/integration-test/java/uk/ac/ebi/tsc/tesk/AuthIT.java
@@ -66,7 +66,7 @@ public class AuthIT {
 
         mockElixir.givenThat(
                 WireMock.get("/")
-                        .willReturn(okJson("{\"sub\" : \"123\",  \"groupNames\" : [\"elixir:GA4GH:GA4GH-CAP:EBI\", \"elixir:GA4GH:GA4GH-CAP:EBI:ADMIN\"]}")));
+                        .willReturn(okJson("{\"sub\" : \"123\",  \"eduperson_entitlement\" : [\"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI#perun.elixir-czech.cz\", \"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI:ADMIN#perun.elixir-czech.cz\"]}")));
 
         mockKubernetes.givenThat(
                 WireMock.post("/apis/batch/v1/namespaces/default/jobs")
@@ -87,7 +87,7 @@ public class AuthIT {
 
         mockElixir.givenThat(
                 WireMock.get("/")
-                        .willReturn(okJson("{\"sub\" : \"123\",  \"groupNames\" : [\"elixir:GA4GH:GA4GH-CAP:EBI\", \"elixir:GA4GH:GA4GH-CAP:EBI:ADMIN\", \"elixir:GA4GH:GA4GH-CAP:EBI:TEST\"]}")));
+                        .willReturn(okJson("{\"sub\" : \"123\",  \"eduperson_entitlement\" : [\"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI#perun.elixir-czech.cz\", \"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI:ADMIN#perun.elixir-czech.cz\", \"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI:TEST#perun.elixir-czech.cz\"]}")));
 
         mockKubernetes.givenThat(
                 WireMock.post("/apis/batch/v1/namespaces/default/jobs")
@@ -108,7 +108,7 @@ public class AuthIT {
 
         mockElixir.givenThat(
                 WireMock.get("/")
-                        .willReturn(okJson("{\"sub\" : \"123\",  \"groupNames\" : [\"elixir:GA4GH:GA4GH-CAP:EBI\", \"elixir:GA4GH:GA4GH-CAP:EBI:ADMIN\"]}")));
+                        .willReturn(okJson("{\"sub\" : \"123\",  \"eduperson_entitlement\" : [\"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI#perun.elixir-czech.cz\", \"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI:ADMIN#perun.elixir-czech.cz\"]}")));
 
         String path = "fromTesToK8s/task.json";
         this.mvc.perform(post("/v1/tasks")
@@ -123,7 +123,7 @@ public class AuthIT {
 
         mockElixir.givenThat(
                 WireMock.get("/")
-                        .willReturn(okJson("{\"sub\" : \"123\",  \"groupNames\" : [\"elixir:GA4GH:GA4GH-CAP:EBI\", \"elixir:GA4GH:GA4GH-CAP:EBI:TEST\"]}")));
+                        .willReturn(okJson("{\"sub\" : \"123\",  \"eduperson_entitlement\" : [\"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI#perun.elixir-czech.cz\", \"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI:TEST#perun.elixir-czech.cz\"]}")));
 
         mockKubernetes.givenThat(
                 WireMock.post("/apis/batch/v1/namespaces/default/jobs")
@@ -144,7 +144,7 @@ public class AuthIT {
 
         mockElixir.givenThat(
                 WireMock.get("/")
-                        .willReturn(okJson("{\"sub\" : \"123\",  \"groupNames\" : [\"elixir:GA4GH:GA4GH-CAP:EBI\", \"elixir:GA4GH:GA4GH-CAP:EBI:TEST\", \"elixir:GA4GH:GA4GH-CAP:EBI:ABC\"]}")));
+                        .willReturn(okJson("{\"sub\" : \"123\",  \"eduperson_entitlement\" : [\"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI#perun.elixir-czech.cz\", \"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI:TEST#perun.elixir-czech.cz\", \"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI:ABC#perun.elixir-czech.cz\"]}")));
 
         mockKubernetes.givenThat(
                 WireMock.post("/apis/batch/v1/namespaces/default/jobs")
@@ -164,7 +164,7 @@ public class AuthIT {
 
         mockElixir.givenThat(
                 WireMock.get("/")
-                        .willReturn(okJson("{\"sub\" : \"123\",  \"groupNames\" : [\"elixir:GA4GH:GA4GH-CAP:EBI\", \"elixir:GA4GH:GA4GH-CAP:EBI:TEST\", \"elixir:GA4GH:GA4GH-CAP:EBI:ABC\"]}")));
+                        .willReturn(okJson("{\"sub\" : \"123\",  \"eduperson_entitlement\" : [\"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI#perun.elixir-czech.cz\", \"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI:TEST#perun.elixir-czech.cz\", \"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI:ABC#perun.elixir-czech.cz\"]}")));
 
         mockKubernetes.givenThat(
                 WireMock.post("/apis/batch/v1/namespaces/default/jobs")
@@ -185,7 +185,7 @@ public class AuthIT {
 
         mockElixir.givenThat(
                 WireMock.get("/")
-                        .willReturn(okJson("{\"sub\" : \"123\",  \"groupNames\" : [\"elixir:GA4GH:GA4GH-CAP:EBI\", \"elixir:GA4GH:GA4GH-CAP:EBI:TEST\", \"elixir:GA4GH:GA4GH-CAP:EBI:XYZ\"]}")));
+                        .willReturn(okJson("{\"sub\" : \"123\",  \"eduperson_entitlement\" : [\"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI#perun.elixir-czech.cz\", \"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI:TEST#perun.elixir-czech.cz\", \"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI:XYZ#perun.elixir-czech.cz\"]}")));
 
         String path = "fromTesToK8s/task.json";
         this.mvc.perform(post("/v1/tasks")
@@ -210,7 +210,7 @@ public class AuthIT {
 
         mockElixir.givenThat(
                 WireMock.get("/")
-                        .willReturn(okJson("{\"sub\":\"123\",\"groupNames\":[\"elixir:different\"]}")));
+                        .willReturn(okJson("{\"sub\":\"123\",\"eduperson_entitlement\":[\"urn:geant:elixir-europe.org:group:elixir:different#perun.elixir-czech.cz\"]}")));
 
         String path = "fromTesToK8s_minimal/task.json";
         this.mvc.perform(post("/v1/tasks")
@@ -225,7 +225,7 @@ public class AuthIT {
 
         mockElixir.givenThat(
                 WireMock.get("/")
-                        .willReturn(okJson("{\"sub\":\"123\",\"groupNames\":[]}")));
+                        .willReturn(okJson("{\"sub\":\"123\",\"eduperson_entitlement\":[]}")));
 
         String path = "fromTesToK8s_minimal/task.json";
         this.mvc.perform(post("/v1/tasks")
@@ -255,7 +255,7 @@ public class AuthIT {
 
         mockElixir.givenThat(
                 WireMock.get("/")
-                        .willReturn(okJson("{\"sub\":\"123\",\"groupNames\":[\"GA4GH:GA4GH-CAP:EBI\"]}")));
+                        .willReturn(okJson("{\"sub\":\"123\",\"eduperson_entitlement\":[\"GA4GH:GA4GH-CAP:EBI#perun.elixir-czech.cz\"]}")));
 
         String path = "fromTesToK8s_minimal/task.json";
         this.mvc.perform(post("/v1/tasks")
@@ -282,7 +282,7 @@ public class AuthIT {
 
         mockElixir.givenThat(
                 WireMock.get("/")
-                        .willReturn(okJson("{\"sub\" : \"123\",  \"groupNames\" : [\"elixir:GA4GH:GA4GH-CAP:EBI\", \"elixir:GA4GH:GA4GH-CAP:EBI:TEST\"]}")));
+                        .willReturn(okJson("{\"sub\" : \"123\",  \"eduperson_entitlement\" : [\"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI#perun.elixir-czech.cz\", \"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI:TEST#perun.elixir-czech.cz\"]}")));
 
         MockUtil.mockGetTaskKubernetesResponses(this.mockKubernetes);
 
@@ -304,7 +304,7 @@ public class AuthIT {
 
         mockElixir.givenThat(
                 WireMock.get("/")
-                        .willReturn(okJson("{\"sub\" : \"123\",  \"groupNames\" : [\"elixir:GA4GH:GA4GH-CAP:EBI\", \"elixir:GA4GH:GA4GH-CAP:EBI:TEST\"]}")));
+                        .willReturn(okJson("{\"sub\" : \"123\",  \"eduperson_entitlement\" : [\"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI#perun.elixir-czech.cz\", \"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI:TEST#perun.elixir-czech.cz\"]}")));
 
         MockUtil.mockGetTaskKubernetesResponses(this.mockKubernetes);
 
@@ -321,7 +321,7 @@ public class AuthIT {
 
         mockElixir.givenThat(
                 WireMock.get("/")
-                        .willReturn(okJson("{\"sub\" : \"124\",  \"groupNames\" : [\"elixir:GA4GH:GA4GH-CAP:EBI\", \"elixir:GA4GH:GA4GH-CAP:EBI:TEST\"]}")));
+                        .willReturn(okJson("{\"sub\" : \"124\",  \"eduperson_entitlement\" : [\"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI#perun.elixir-czech.cz\", \"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI:TEST#perun.elixir-czech.cz\"]}")));
 
         MockUtil.mockGetTaskKubernetesResponses(this.mockKubernetes);
 
@@ -338,7 +338,7 @@ public class AuthIT {
 
         mockElixir.givenThat(
                 WireMock.get("/")
-                        .willReturn(okJson("{\"sub\" : \"124\",  \"groupNames\" : [\"elixir:GA4GH:GA4GH-CAP:EBI\", \"elixir:GA4GH:GA4GH-CAP:EBI:TEST\"]}")));
+                        .willReturn(okJson("{\"sub\" : \"124\",  \"eduperson_entitlement\" : [\"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI#perun.elixir-czech.cz\", \"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI:TEST#perun.elixir-czech.cz\"]}")));
 
         MockUtil.mockGetTaskKubernetesResponses(this.mockKubernetes);
 
@@ -358,7 +358,7 @@ public class AuthIT {
 
         mockElixir.givenThat(
                 WireMock.get("/")
-                        .willReturn(okJson("{\"sub\" : \"124\",  \"groupNames\" : [\"elixir:GA4GH:GA4GH-CAP:EBI\", \"elixir:GA4GH:GA4GH-CAP:EBI:TEST:ADMIN\"]}")));
+                        .willReturn(okJson("{\"sub\" : \"124\",  \"eduperson_entitlement\" : [\"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI#perun.elixir-czech.cz\", \"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI:TEST:ADMIN#perun.elixir-czech.cz\"]}")));
 
         MockUtil.mockGetTaskKubernetesResponses(this.mockKubernetes);
 
@@ -378,7 +378,7 @@ public class AuthIT {
 
         mockElixir.givenThat(
                 WireMock.get("/")
-                        .willReturn(okJson("{\"sub\" : \"123\",  \"groupNames\" : [\"elixir:GA4GH:GA4GH-CAP:EBI\"]}")));
+                        .willReturn(okJson("{\"sub\" : \"123\",  \"eduperson_entitlement\" : [\"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI#perun.elixir-czech.cz\"]}")));
 
         MockUtil.mockGetTaskKubernetesResponses(this.mockKubernetes);
 
@@ -398,7 +398,7 @@ public class AuthIT {
 
         mockElixir.givenThat(
                 WireMock.get("/")
-                        .willReturn(okJson("{\"sub\" : \"xyz\",  \"groupNames\" : [\"elixir:GA4GH:GA4GH-CAP:EBI:ADMIN\"]}")));
+                        .willReturn(okJson("{\"sub\" : \"xyz\",  \"eduperson_entitlement\" : [\"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI:ADMIN#perun.elixir-czech.cz\"]}")));
 
         MockUtil.mockGetTaskKubernetesResponses(this.mockKubernetes);
 
@@ -418,7 +418,7 @@ public class AuthIT {
 
         mockElixir.givenThat(
                 WireMock.get("/")
-                        .willReturn(okJson("{\"sub\" : \"123\",  \"groupNames\" : [\"elixir:GA4GH:GA4GH-CAP:EBI\",\"elixir:GA4GH:GA4GH-CAP:EBI:TEST\"]}")));
+                        .willReturn(okJson("{\"sub\" : \"123\",  \"eduperson_entitlement\" : [\"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI#perun.elixir-czech.cz\",\"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI:TEST#perun.elixir-czech.cz\"]}")));
 
         mockKubernetes.givenThat(
                 WireMock.get("/apis/batch/v1/namespaces/default/jobs?labelSelector=job-type%3Dtaskmaster" +
@@ -435,7 +435,7 @@ public class AuthIT {
 
         mockElixir.givenThat(
                 WireMock.get("/")
-                        .willReturn(okJson("{\"sub\" : \"123\",  \"groupNames\" : [\"elixir:GA4GH:GA4GH-CAP:EBI:ADMIN\"]}")));
+                        .willReturn(okJson("{\"sub\" : \"123\",  \"eduperson_entitlement\" : [\"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI:ADMIN#perun.elixir-czech.cz\"]}")));
 
         mockKubernetes.givenThat(
                 WireMock.get("/apis/batch/v1/namespaces/default/jobs?labelSelector=job-type%3Dtaskmaster")
@@ -451,7 +451,7 @@ public class AuthIT {
 
         mockElixir.givenThat(
                 WireMock.get("/")
-                        .willReturn(okJson("{\"sub\" : \"123\",  \"groupNames\" : [\"elixir:GA4GH:GA4GH-CAP:EBI:TEST:ADMIN\"]}")));
+                        .willReturn(okJson("{\"sub\" : \"123\",  \"eduperson_entitlement\" : [\"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI:TEST:ADMIN#perun.elixir-czech.cz\"]}")));
 
         mockKubernetes.givenThat(
                 WireMock.get("/apis/batch/v1/namespaces/default/jobs?labelSelector=job-type%3Dtaskmaster" +
@@ -468,7 +468,7 @@ public class AuthIT {
 
         mockElixir.givenThat(
                 WireMock.get("/")
-                        .willReturn(okJson("{\"sub\" : \"123\",  \"groupNames\" : [\"elixir:GA4GH:GA4GH-CAP:EBI:ABC:ADMIN\",\"elixir:GA4GH:GA4GH-CAP:EBI:TEST\"]}")));
+                        .willReturn(okJson("{\"sub\" : \"123\",  \"eduperson_entitlement\" : [\"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI:ABC:ADMIN#perun.elixir-czech.cz\",\"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP:EBI:TEST#perun.elixir-czech.cz\"]}")));
 
         mockKubernetes.givenThat(
                 WireMock.get("/apis/batch/v1/namespaces/default/jobs?labelSelector=job-type%3Dtaskmaster" +
@@ -499,7 +499,7 @@ public class AuthIT {
 
         mockElixir.givenThat(
                 WireMock.get("/")
-                        .willReturn(okJson("{\"sub\" : \"123\",  \"groupNames\" : [\"sth\",\"elixir:GA4GH:GA4GH-CAP\"]}")));
+                        .willReturn(okJson("{\"sub\" : \"123\",  \"eduperson_entitlement\" : [\"sth\",\"urn:geant:elixir-europe.org:group:elixir:GA4GH:GA4GH-CAP#perun.elixir-czech.cz\"]}")));
 
         this.mvc.perform(get("/v1/tasks")
                 .header("Authorization", "Bearer BAR"))

--- a/src/main/java/uk/ac/ebi/tsc/tesk/config/security/AuthorisationProperties.java
+++ b/src/main/java/uk/ac/ebi/tsc/tesk/config/security/AuthorisationProperties.java
@@ -12,24 +12,25 @@ import org.springframework.context.annotation.Configuration;
 @ConfigurationProperties(prefix = "tesk.api.authorisation")
 public class AuthorisationProperties {
     /**
-     * Delimiter of nested group names (:)
+     * The name of the claim in userInfo that contains user's group membership
      */
-    private String delimiter;
-    /**
-     * Top level group name (all groups will have be direct or indirect subgroups of the group)
-     */
-    private String parentGroup;
-    /**
-     * Environment subgroup name - subgroup of base group representing single installation of TESK (EBI, CSC)
-     */
-    private String envSubgroup;
+    private String groupsClaim;
 
     /**
-     * Basic group required to perform any operation (parentGroup + envSubgroup)
+     * The prefix before actual group name
      */
-    private String baseGroup;
+    private String groupPrefix;
     /**
-     * Base group name + delimiter (to use as a prefix to even more nested groups)
+     * The suffix after actual group name
+     */
+    private String groupSuffix = "";
+
+    /**
+     * Full name of base group required to perform any operation (prefix + parentGroup + envSubgroup + suffix)
+     */
+    private String baseGroupFull;
+    /**
+     * (Prefix) + Base group name + delimiter (to use as a prefix to even more nested groups)
      */
     private String baseGroupPrefix;
     /**
@@ -38,40 +39,40 @@ public class AuthorisationProperties {
     private String adminSubgroup;
 
     /**
-     * Group representing admins of single installation of TESK
+     * Full name of a group representing admins of a single installation of TESK
      */
-    private String adminGroup;
+    private String adminGroupFull;
 
-    public String getDelimiter() {
-        return delimiter;
+    public String getGroupsClaim() {
+        return groupsClaim;
     }
 
-    public void setDelimiter(String delimiter) {
-        this.delimiter = delimiter;
+    public void setGroupsClaim(String groupsClaim) {
+        this.groupsClaim = groupsClaim;
     }
 
-    public String getParentGroup() {
-        return parentGroup;
+    public String getGroupPrefix() {
+        return groupPrefix;
     }
 
-    public void setParentGroup(String parentGroup) {
-        this.parentGroup = parentGroup;
+    public void setGroupPrefix(String groupPrefix) {
+        this.groupPrefix = groupPrefix;
     }
 
-    public String getEnvSubgroup() {
-        return envSubgroup;
+    public String getGroupSuffix() {
+        return groupSuffix;
     }
 
-    public void setEnvSubgroup(String envSubgroup) {
-        this.envSubgroup = envSubgroup;
+    public void setGroupSuffix(String groupSuffix) {
+        this.groupSuffix = groupSuffix;
     }
 
-    public String getBaseGroup() {
-        return baseGroup;
+    public String getBaseGroupFull() {
+        return baseGroupFull;
     }
 
-    public void setBaseGroup(String baseGroup) {
-        this.baseGroup = baseGroup;
+    public void setBaseGroupFull(String baseGroupFull) {
+        this.baseGroupFull = baseGroupFull;
     }
 
     public String getAdminSubgroup() {
@@ -90,11 +91,11 @@ public class AuthorisationProperties {
         this.baseGroupPrefix = baseGroupPrefix;
     }
 
-    public String getAdminGroup() {
-        return adminGroup;
+    public String getAdminGroupFull() {
+        return adminGroupFull;
     }
 
-    public void setAdminGroup(String adminGroup) {
-        this.adminGroup = adminGroup;
+    public void setAdminGroupFull(String adminGroupFull) {
+        this.adminGroupFull = adminGroupFull;
     }
 }

--- a/src/main/java/uk/ac/ebi/tsc/tesk/config/security/ElixirPrincipalExtractor.java
+++ b/src/main/java/uk/ac/ebi/tsc/tesk/config/security/ElixirPrincipalExtractor.java
@@ -27,8 +27,8 @@ public class ElixirPrincipalExtractor implements PrincipalExtractor {
     ElixirPrincipalExtractor(AuthoritiesExtractor groupsExtractor, AuthorisationProperties authorisationProperties) {
         this.groupsExtractor = groupsExtractor;
         this.authorisationProperties = authorisationProperties;
-        MEMBERED_GROUP = Pattern.compile("^" + authorisationProperties.getBaseGroupPrefix() + "([^:]+)");
-        MANAGED_GROUP = Pattern.compile("^" + authorisationProperties.getBaseGroupPrefix() + "([^:]+):" + authorisationProperties.getAdminSubgroup());
+        MEMBERED_GROUP = Pattern.compile("^" + authorisationProperties.getBaseGroupPrefix() + "([^:]+)" + authorisationProperties.getGroupSuffix());
+        MANAGED_GROUP = Pattern.compile("^" + authorisationProperties.getBaseGroupPrefix() + "([^:]+):" + authorisationProperties.getAdminSubgroup() + authorisationProperties.getGroupSuffix());
     }
 
 
@@ -42,19 +42,19 @@ public class ElixirPrincipalExtractor implements PrincipalExtractor {
                 .familyName(Optional.ofNullable(map.get("family_name")).map(Object::toString).orElse(null));
 
         Set<String> allGroups = this.groupsExtractor.extractAuthorities(map).stream().map(GrantedAuthority::getAuthority).collect(Collectors.toSet());
-        Set<String> memberedGroups = allGroups.stream().filter(name -> MEMBERED_GROUP.matcher(name).matches() && !authorisationProperties.getAdminGroup().equals(name)).
+        Set<String> memberedGroups = allGroups.stream().filter(name -> MEMBERED_GROUP.matcher(name).matches() && !authorisationProperties.getAdminGroupFull().equals(name)).
                 map(name -> {
                     Matcher matcher = MEMBERED_GROUP.matcher(name);
                     matcher.matches();
                     return matcher.group(1);
                 }).collect(Collectors.toSet());
-        Set<String> managedGroups = allGroups.stream().filter(name -> MANAGED_GROUP.matcher(name).matches() && !authorisationProperties.getAdminGroup().equals(name)).
+        Set<String> managedGroups = allGroups.stream().filter(name -> MANAGED_GROUP.matcher(name).matches() && !authorisationProperties.getAdminGroupFull().equals(name)).
                 map(name -> {
                     Matcher matcher = MANAGED_GROUP.matcher(name);
                     matcher.matches();
                     return matcher.group(1);
                 }).collect(Collectors.toSet());
-        boolean isAdmin = allGroups.stream().anyMatch(name -> authorisationProperties.getAdminGroup().equals(name));
+        boolean isAdmin = allGroups.stream().anyMatch(name -> authorisationProperties.getAdminGroupFull().equals(name));
         return builder.allGroups(allGroups).teskMemberedGroups(memberedGroups).teskManagedGroups(managedGroups).teskAdmin(isAdmin).build();
     }
 }

--- a/src/main/java/uk/ac/ebi/tsc/tesk/config/security/GroupNamesSecurityExtractor.java
+++ b/src/main/java/uk/ac/ebi/tsc/tesk/config/security/GroupNamesSecurityExtractor.java
@@ -20,13 +20,18 @@ import org.springframework.boot.autoconfigure.security.oauth2.resource.FixedAuth
  */
 public class GroupNamesSecurityExtractor implements AuthoritiesExtractor {
 
-    private static final String AUTHORITIES = "groupNames";
+    public GroupNamesSecurityExtractor(String authoritiesClaim, String groupPrefix) {
+        this.authoritiesClaim = authoritiesClaim;
+        this.groupPrefix = groupPrefix;
+    }
+    private final String authoritiesClaim;
+    private final String groupPrefix;
 
     @Override
     public List<GrantedAuthority> extractAuthorities(Map<String, Object> map) {
-        String authorities = "elixir:USER";
-        if (map.containsKey(AUTHORITIES)) {
-            authorities = asAuthorities(map.get(AUTHORITIES));
+        String authorities = this.groupPrefix + ":USER";
+        if (map.containsKey(this.authoritiesClaim)) {
+            authorities = asAuthorities(map.get(this.authoritiesClaim));
         }
         return AuthorityUtils.commaSeparatedStringToAuthorityList(authorities);
     }

--- a/src/main/java/uk/ac/ebi/tsc/tesk/config/security/ResourceServerConfiguration.java
+++ b/src/main/java/uk/ac/ebi/tsc/tesk/config/security/ResourceServerConfiguration.java
@@ -65,11 +65,11 @@ public class ResourceServerConfiguration extends ResourceServerConfigurerAdapter
     }
 
     /**
-     * Magic, that changes default role prefix from ROLE_ to elixir:
+     * Magic, that changes default role prefix from ROLE_ to (...)elixir:
      */
     @Bean
     public GrantedAuthorityDefaults grantedAuthorityDefaults() {
-        return new GrantedAuthorityDefaults("elixir:");
+        return new GrantedAuthorityDefaults(this.authorisationProperties.getGroupPrefix());
     }
 
     /**
@@ -77,7 +77,7 @@ public class ResourceServerConfiguration extends ResourceServerConfigurerAdapter
      */
     @Bean
     public AuthoritiesExtractor authoritiesExtractor() {
-        return new GroupNamesSecurityExtractor();
+        return new GroupNamesSecurityExtractor(authorisationProperties.getGroupsClaim(), authorisationProperties.getGroupPrefix());
     }
 
     /**

--- a/src/main/java/uk/ac/ebi/tsc/tesk/config/security/User.java
+++ b/src/main/java/uk/ac/ebi/tsc/tesk/config/security/User.java
@@ -177,8 +177,11 @@ public class User implements Serializable, UserDetails, Principal {
                 ", givenName='" + givenName + '\'' +
                 ", familyName='" + familyName + '\'' +
                 ", email='" + email + '\'' +
-                ", allGroups=(" + StringUtils.collectionToCommaDelimitedString(allGroups) +
-                ")}";
+                ", allGroups=(" + StringUtils.collectionToCommaDelimitedString(allGroups) + ")" +
+                ", memberedGroups=(" + StringUtils.collectionToCommaDelimitedString(teskMemberedGroups) + ")" +
+                ", managedGroups=(" + StringUtils.collectionToCommaDelimitedString(teskManagedGroups) + ")" +
+                ", iasAdmin=" + isTeskAdmin() +
+                "}";
     }
 
     @Override

--- a/src/main/java/uk/ac/ebi/tsc/tesk/service/TesService.java
+++ b/src/main/java/uk/ac/ebi/tsc/tesk/service/TesService.java
@@ -21,7 +21,7 @@ public interface TesService {
      * Creates new TES task, by converting input and calling create method.
      * In case of detecting duplicated task ID, retries with new generated ID (up to a limit of retries)
      */
-    @PreAuthorize("hasRole(@authorisationProperties.baseGroup) AND" +
+    @PreAuthorize("hasRole(@authorisationProperties.baseGroupFull) AND" +
             "(#user.member OR #user.teskAdmin) AND" +
             "(#task.tags?.get('GROUP_NAME') == null OR #user.isGroupMember(#task.tags['GROUP_NAME']))")
     TesCreateTaskResponse createTask(TesTask task, User user);
@@ -63,6 +63,6 @@ public interface TesService {
      *
      * @param taskId - TES task ID (==taskmaster's job name)
      */
-    @PreAuthorize("hasRole(@authorisationProperties.baseGroup)")
+    @PreAuthorize("hasRole(@authorisationProperties.baseGroupFull)")
     void cancelTask(String taskId);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,13 +27,19 @@ tesk.api.taskmaster.debug=false
 
 spring.profiles.active=noauth
 #group authorisation settings
+tesk.api.authorisation.groups-claim=eduperson_entitlement
 tesk.api.authorisation.delimiter=:
-tesk.api.authorisation.parent-group=elixir:GA4GH:GA4GH-CAP
+tesk.api.authorisation.group-prefix=urn:geant:elixir-europe.org:group:elixir:
+tesk.api.authorisation.group-suffix=#perun.elixir-czech.cz
+tesk.api.authorisation.parent-group=GA4GH:GA4GH-CAP
 tesk.api.authorisation.env-subgroup=EBI
 tesk.api.authorisation.base-group=${tesk.api.authorisation.parent-group}${tesk.api.authorisation.delimiter}${tesk.api.authorisation.env-subgroup}
-tesk.api.authorisation.base-group-prefix=${tesk.api.authorisation.base-group}${tesk.api.authorisation.delimiter}
-tesk.api.authorisation.admin-group=${tesk.api.authorisation.base-group-prefix}${tesk.api.authorisation.admin-subgroup}
 tesk.api.authorisation.admin-subgroup=ADMIN
+tesk.api.authorisation.base-group-nosuffix=${tesk.api.authorisation.group-prefix}${tesk.api.authorisation.base-group}
+tesk.api.authorisation.base-group-prefix=${tesk.api.authorisation.base-group-nosuffix}${tesk.api.authorisation.delimiter}
+tesk.api.authorisation.base-group-full=${tesk.api.authorisation.base-group-nosuffix}${tesk.api.authorisation.group-suffix}
+tesk.api.authorisation.admin-group-full=${tesk.api.authorisation.base-group-prefix}${tesk.api.authorisation.admin-subgroup}${tesk.api.authorisation.group-suffix}
+
 tesk.api.authorisation.admin-subgroup-suffix=${tesk.api.authorisation.delimiter}${tesk.api.authorisation.admin-subgroup}
 #server.port=8082
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -49,4 +49,4 @@ tesk.api.swagger-oauth.authorization-endpoint=https://login.elixir-czech.org/oid
 tesk.api.swagger-oauth.token-endpoint=https://login.elixir-czech.org/oidc/token
 tesk.api.swagger-oauth.client-id=changeme
 tesk.api.swagger-oauth.client-secret=changeme
-tesk.api.swagger-oauth.scopes=openid:Standard openid,groupNames:Access to groups membership,profile:Identity info about user,email:Email
+tesk.api.swagger-oauth.scopes=openid:Standard openid,${tesk.api.authorisation.groups-claim}:Access to groups membership,profile:Identity info about user,email:Email

--- a/src/test/java/uk/ac/ebi/tsc/tesk/config/security/ElixirPrincipalExtractorTest.java
+++ b/src/test/java/uk/ac/ebi/tsc/tesk/config/security/ElixirPrincipalExtractorTest.java
@@ -14,22 +14,30 @@ import static org.junit.Assert.assertThat;
 
 public class ElixirPrincipalExtractorTest {
 
-    private ElixirPrincipalExtractor extractor;
+    private ElixirPrincipalExtractor extractorNoSuffix;
+    private ElixirPrincipalExtractor extractorSuffix;
 
     @Before
     public void setUp() {
         AuthorisationProperties properties = new AuthorisationProperties();
         properties.setBaseGroupPrefix("BASE_GROUP:");
         properties.setAdminSubgroup("ADMIN");
-        properties.setAdminGroup("BASE_GROUP:ADMIN");
-        extractor = new ElixirPrincipalExtractor(new GroupNamesSecurityExtractor(), properties);
+        properties.setAdminGroupFull("BASE_GROUP:ADMIN");
+        extractorNoSuffix = new ElixirPrincipalExtractor(new GroupNamesSecurityExtractor("groupNames", "whatever"), properties);
+        AuthorisationProperties propertiesSuffix = new AuthorisationProperties();
+        propertiesSuffix.setBaseGroupPrefix("prefix:BASE_GROUP:");
+        propertiesSuffix.setAdminSubgroup("ADMIN");
+        propertiesSuffix.setAdminGroupFull("prefix:BASE_GROUP:ADMIN#suffix");
+        propertiesSuffix.setGroupSuffix("#suffix");
+        extractorNoSuffix = new ElixirPrincipalExtractor(new GroupNamesSecurityExtractor("groupNames", "whatever"), properties);
+        extractorSuffix = new ElixirPrincipalExtractor(new GroupNamesSecurityExtractor("groupNames", "whatever"), propertiesSuffix);
     }
 
     @Test
     public void extractPrincipal() {
         User modelUser = User.builder("123").preferredUsername("user_123").email("jodo@yahoo.com")
                 .name("Jo Do").givenName("Jo").familyName("Do").teskAdmin(false)
-                .teskMemberedGroups(new HashSet<>()).teskManagedGroups(new HashSet<>()).allGroups(StringUtils.commaDelimitedListToSet("elixir:USER")).build();
+                .teskMemberedGroups(new HashSet<>()).teskManagedGroups(new HashSet<>()).allGroups(StringUtils.commaDelimitedListToSet("whatever:USER")).build();
         Map<String, Object> map = new HashMap<>();
         map.put("sub", "123");
         map.put("preferred_username", "user_123");
@@ -37,9 +45,12 @@ public class ElixirPrincipalExtractorTest {
         map.put("given_name", "Jo");
         map.put("family_name", "Do");
         map.put("email", "jodo@yahoo.com");
-        Object result = extractor.extractPrincipal(map);
-        User user = (User) result;
-        assertThat(user, is(modelUser));
+        Object result1 = extractorNoSuffix.extractPrincipal(map);
+        Object result2 = extractorSuffix.extractPrincipal(map);
+        User user1 = (User) result1;
+        User user2 = (User) result2;
+        assertThat(user1, is(modelUser));
+        assertThat(user2, is(modelUser));
     }
 
     @Test
@@ -50,7 +61,19 @@ public class ElixirPrincipalExtractorTest {
         Map<String, Object> map = new HashMap<>();
         map.put("sub", "123");
         map.put("groupNames", Arrays.asList("OTHER", "BASE_GROUP:ADMIN", "BASE_GROUP:TEST", "BASE_GROUP:ABC", "BASE_GROUP:XYZ:ADMIN"));
-        Object result = extractor.extractPrincipal(map);
+        Object result = extractorNoSuffix.extractPrincipal(map);
+        User user = (User) result;
+        assertThat(user, is(modelUser));
+    }
+    @Test
+    public void extractPrincipalWithGroupsSuffixes() {
+        User modelUser = User.builder("123").teskAdmin(true)
+                .teskMemberedGroups(StringUtils.commaDelimitedListToSet("TEST,ABC")).teskManagedGroups(StringUtils.commaDelimitedListToSet("XYZ"))
+                .allGroups(StringUtils.commaDelimitedListToSet("prefix:OTHER#suffix,prefix:BASE_GROUP:ADMIN#suffix,prefix:BASE_GROUP:TEST#suffix,prefix:BASE_GROUP:ABC#suffix,prefix:BASE_GROUP:XYZ:ADMIN#suffix")).build();
+        Map<String, Object> map = new HashMap<>();
+        map.put("sub", "123");
+        map.put("groupNames", Arrays.asList("prefix:OTHER#suffix", "prefix:BASE_GROUP:ADMIN#suffix", "prefix:BASE_GROUP:TEST#suffix", "prefix:BASE_GROUP:ABC#suffix", "prefix:BASE_GROUP:XYZ:ADMIN#suffix"));
+        Object result = extractorSuffix.extractPrincipal(map);
         User user = (User) result;
         assertThat(user, is(modelUser));
     }

--- a/src/test/java/uk/ac/ebi/tsc/tesk/config/security/GroupNamesSecurityExtractorTest.java
+++ b/src/test/java/uk/ac/ebi/tsc/tesk/config/security/GroupNamesSecurityExtractorTest.java
@@ -16,7 +16,7 @@ public class GroupNamesSecurityExtractorTest {
 
     @Test
     public void extractAuthorities_array() {
-        GroupNamesSecurityExtractor extractor = new GroupNamesSecurityExtractor();
+        GroupNamesSecurityExtractor extractor = new GroupNamesSecurityExtractor("groupNames", "whatever");
         Map<String, Object> authorities = new HashMap<>();
         authorities.put("groupNames", new String[]{"abc", "xyz"});
         List<GrantedAuthority> result = extractor.extractAuthorities(authorities);
@@ -25,19 +25,19 @@ public class GroupNamesSecurityExtractorTest {
 
     @Test
     public void extractAuthorities_collection() {
-        GroupNamesSecurityExtractor extractor = new GroupNamesSecurityExtractor();
+        GroupNamesSecurityExtractor extractor = new GroupNamesSecurityExtractor("entitlement", "whatever");
         Map<String, Object> authorities = new HashMap<>();
-        authorities.put("groupNames", Arrays.asList("abc", "xyz"));
+        authorities.put("entitlement", Arrays.asList("abc", "xyz"));
         List<GrantedAuthority> result = extractor.extractAuthorities(authorities);
         assertThat(result, containsInAnyOrder(new SimpleGrantedAuthority("abc"), new SimpleGrantedAuthority("xyz")));
     }
 
     @Test
     public void extractAuthorities_noGroups() {
-        GroupNamesSecurityExtractor extractor = new GroupNamesSecurityExtractor();
+        GroupNamesSecurityExtractor extractor = new GroupNamesSecurityExtractor("groupNames", "prefix");
         Map<String, Object> authorities = new HashMap<>();
         authorities.put("sthElse", new String[]{"abc", "xyz"});
         List<GrantedAuthority> result = extractor.extractAuthorities(authorities);
-        assertThat(result, containsInAnyOrder(new SimpleGrantedAuthority("elixir:USER")));
+        assertThat(result, containsInAnyOrder(new SimpleGrantedAuthority("prefix:USER")));
     }
 }


### PR DESCRIPTION
Authorisation based on group membership claims a bit more configurable:
- the claim name is configurable
- the group names can have suffixes.
The default values work for Elixir AAI.