### PR TITLE
Allow changing the default filer image name

### DIFF
--- a/src/main/java/uk/ac/ebi/tsc/tesk/config/KubernetesObjectsSupplier.java
+++ b/src/main/java/uk/ac/ebi/tsc/tesk/config/KubernetesObjectsSupplier.java
@@ -62,6 +62,12 @@ public class KubernetesObjectsSupplier {
             V1Container taskmasterContainer = job.getSpec().getTemplate().getSpec().getContainers().get(0).
                     image(new StringJoiner(":").add(taskmasterEnvProperties.getImageName()).add(taskmasterEnvProperties.getImageVersion()).toString())
                     .addArgsItem("-n").addArgsItem(namespace).addArgsItem("-fv").addArgsItem(this.taskmasterEnvProperties.getFilerImageVersion());
+
+            if (this.taskmasterEnvProperties.getFilerImageName() != null) {
+                taskmasterContainer.addArgsItem("-fn")
+                        .addArgsItem(this.taskmasterEnvProperties.getFilerImageName());
+            }
+
             if (this.taskmasterEnvProperties.isDebug()) {
                 taskmasterContainer.addArgsItem("-d")
                         .setImagePullPolicy("Always");

--- a/src/main/java/uk/ac/ebi/tsc/tesk/config/TaskmasterEnvProperties.java
+++ b/src/main/java/uk/ac/ebi/tsc/tesk/config/TaskmasterEnvProperties.java
@@ -25,6 +25,11 @@ public class TaskmasterEnvProperties {
     private String imageVersion;
 
     /**
+     * Filer image name
+     */
+    private String filerImageName;
+
+    /**
      * Filer image version
      */
     private String filerImageVersion;
@@ -67,6 +72,14 @@ public class TaskmasterEnvProperties {
 
     public void setImageName(String imageName) {
         this.imageName = imageName;
+    }
+
+    public String getFilerImageName() {
+        return filerImageName;
+    }
+
+    public void setFilerImageName(String filerImageName) {
+        this.filerImageName = filerImageName;
     }
 
     public String getFilerImageVersion() {

--- a/src/test/java/uk/ac/ebi/tsc/tesk/util/component/TesKubernetesConverterDefaultFilerImageTest.java
+++ b/src/test/java/uk/ac/ebi/tsc/tesk/util/component/TesKubernetesConverterDefaultFilerImageTest.java
@@ -1,0 +1,305 @@
+package uk.ac.ebi.tsc.tesk.util.component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import io.kubernetes.client.models.V1Job;
+import io.kubernetes.client.models.V1JobStatus;
+import io.kubernetes.client.models.V1ObjectMeta;
+import io.kubernetes.client.models.V1PodList;
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.json.JsonContentAssert;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.util.StringUtils;
+import uk.ac.ebi.tsc.tesk.TestUtils;
+import uk.ac.ebi.tsc.tesk.config.GsonConfig;
+import uk.ac.ebi.tsc.tesk.config.KubernetesObjectsSupplier;
+import uk.ac.ebi.tsc.tesk.config.TaskmasterEnvProperties;
+import uk.ac.ebi.tsc.tesk.config.security.User;
+import uk.ac.ebi.tsc.tesk.model.TesState;
+import uk.ac.ebi.tsc.tesk.model.TesTask;
+import uk.ac.ebi.tsc.tesk.util.constant.Constants;
+import uk.ac.ebi.tsc.tesk.util.constant.K8sConstants;
+import uk.ac.ebi.tsc.tesk.util.data.TaskBuilder;
+
+import java.io.*;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static uk.ac.ebi.tsc.tesk.util.constant.Constants.LABEL_TASKSTATE_KEY;
+import static uk.ac.ebi.tsc.tesk.util.constant.Constants.LABEL_TASKSTATE_VALUE_CANC;
+
+
+/**
+ * @author Ania Niewielska <aniewielska@ebi.ac.uk>
+ */
+@RunWith(SpringRunner.class)
+@JsonTest
+@TestPropertySource(locations = {"classpath:application.properties"},
+        properties = {"tesk.api.taskmaster.image-name = task-minimal-image-name",
+                "tesk.api.taskmaster.image-version = task-minimal-image-version",
+                "tesk.api.k8s.namespace = test-namespace"})
+@EnableConfigurationProperties(TaskmasterEnvProperties.class)
+public class TesKubernetesConverterDefaultFilerImageTest {
+
+    @MockBean
+    private JobNameGenerator jobNameGenerator;
+
+    @TestConfiguration
+    @Import({KubernetesObjectsSupplier.class, GsonConfig.class})
+    static class Configuration {
+    }
+
+    @Autowired
+    @Qualifier("executor")
+    Supplier<V1Job> executorTemplateSupplier;
+
+    @Autowired
+    @Qualifier("taskmaster")
+    Supplier<V1Job> taskmasterTemplateSupplier;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private Gson gson;
+
+
+    private TesKubernetesConverter converter;
+
+    @Before
+    public void setUpConverter() {
+
+        this.converter = new TesKubernetesConverter(executorTemplateSupplier, taskmasterTemplateSupplier,
+                objectMapper, gson);
+    }
+
+    @Test
+    public void fromTesTaskToK8sJob_defaultFilerImage() throws IOException {
+
+        given(this.jobNameGenerator.getTaskMasterName()).willReturn("task-98605447");
+
+        Resource inputTaskFile = new ClassPathResource("fromTesToK8s_defaultFilerImage/task.json");
+        TesTask inputTask;
+        try (InputStream inputStream = inputTaskFile.getInputStream();
+             Reader reader = new BufferedReader(new InputStreamReader(inputStream))) {
+            inputTask = this.objectMapper.readValue(reader, TesTask.class);
+        }
+        V1Job outputJob = this.converter.fromTesTaskToK8sJob(inputTask, User.builder("test-user-id").teskMemberedGroups(StringUtils.commaDelimitedListToSet("ABC")).build());
+        assertNull(outputJob.getMetadata().getAnnotations().get("tes-task-name"));
+        //testing annotation with entire serialized task content..
+        assertThat(outputJob.getMetadata().getAnnotations().get("json-input")).isNotEmpty();
+        //..comparing jsons
+        JsonContentAssert annotationWithEntireTask = new JsonContentAssert(this.getClass(), outputJob.getMetadata().getAnnotations().get("json-input"));
+        annotationWithEntireTask.isEqualToJson(inputTaskFile);
+
+        //..and one example path
+        annotationWithEntireTask.extractingJsonPathArrayValue("@.executors[0].command").startsWith("echo");
+
+        assertThat(outputJob.getMetadata().getLabels().get("job-type"), is("taskmaster"));
+        assertThat(outputJob.getMetadata().getLabels().get("creator-user-id"), is("test-user-id"));
+        assertThat(outputJob.getMetadata().getLabels().get("creator-group-name"), is("ABC"));
+
+        assertThat(outputJob.getSpec().getTemplate().getSpec().getContainers().get(0).getArgs().get(0), is("$(JSON_INPUT)"));
+
+        JsonContentAssert taskMasterInputJson = new JsonContentAssert(this.getClass(), outputJob.getSpec().getTemplate().getSpec().
+                getContainers().get(0).getEnv().stream().filter(env -> env.getName().equals("JSON_INPUT")).findAny().get().getValue());
+        taskMasterInputJson.hasJsonPathValue("outputs");
+        taskMasterInputJson.extractingJsonPathNumberValue("outputs.size()").isEqualTo(0);
+        taskMasterInputJson.extractingJsonPathNumberValue("inputs.size()").isEqualTo(0);
+        taskMasterInputJson.extractingJsonPathNumberValue("volumes.size()").isEqualTo(0);
+        taskMasterInputJson.extractingJsonPathMapValue("executors[0].metadata.annotations").isEmpty();
+        taskMasterInputJson.extractingJsonPathArrayValue("executors[*].metadata.labels['job-type']").containsOnly("executor").hasSize(1);
+        taskMasterInputJson.extractingJsonPathArrayValue("executors[*].metadata.labels['taskmaster-name']").containsOnly("task-98605447").hasSize(1);
+
+        taskMasterInputJson.extractingJsonPathArrayValue("executors[*].spec.template.spec.restartPolicy").containsOnly("Never").hasSize(1);
+        taskMasterInputJson.extractingJsonPathMapValue("executors[0].spec.template.spec.containers[0].resources").isEmpty();
+
+        taskMasterInputJson.extractingJsonPathArrayValue("executors[0].spec.template.spec.containers[0].command").containsExactly("echo", "hello world");
+        taskMasterInputJson.extractingJsonPathStringValue("executors[0].spec.template.spec.containers[0].image").isEqualTo("ubuntu");
+
+        taskMasterInputJson.extractingJsonPathMapValue("executors[0].spec.template.spec.containers[0]").containsOnlyKeys("name", "image", "command", "resources");
+
+        taskMasterInputJson.extractingJsonPathNumberValue("resources.disk_gb").isEqualTo(0.1);
+
+        taskMasterInputJson.isEqualToJson(new ClassPathResource("fromTesToK8s_defaultFilerImage/taskmaster_param.json"), JSONCompareMode.NON_EXTENSIBLE);
+
+        Resource outputJobFile = new ClassPathResource("fromTesToK8s_defaultFilerImage/job.json");
+        V1Job expectedJob;
+        try (InputStream inputStream = outputJobFile.getInputStream();
+             Reader reader = new BufferedReader(new InputStreamReader(inputStream))) {
+            expectedJob = this.gson.fromJson(reader, V1Job.class);
+        }
+        expectedJob.getMetadata().setAnnotations(null);
+        outputJob.getMetadata().setAnnotations(null);
+        expectedJob.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().stream().filter(env -> env.getName().equals(Constants.TASKMASTER_INPUT)).forEach(env -> env.setValue(""));
+        outputJob.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().stream().filter(env -> env.getName().equals(Constants.TASKMASTER_INPUT)).forEach(env -> env.setValue(""));
+        //comparing fields of resulting Job object and pattern Job objects other those with JSON values, which were cleared in previous lines (JSON strings do not have to be exactly equal to pattern).
+        assertEquals(expectedJob, outputJob);
+    }
+
+    private TaskBuilder prepareBaseTaskBuider(boolean withExecutors, boolean withPods) throws IOException {
+        TaskBuilder taskBuilder = TaskBuilder.newSingleTask();
+        taskBuilder.addJob(this.gson.fromJson(TestUtils.getFileContentFromResources("fromK8sToTes_defaultFilerImage/taskmaster.json"), V1Job.class));
+        if (withExecutors) {
+            taskBuilder.addJob(this.gson.fromJson(TestUtils.getFileContentFromResources("fromK8sToTes_defaultFilerImage/executor_00.json"), V1Job.class));
+            taskBuilder.addJob(this.gson.fromJson(TestUtils.getFileContentFromResources("fromK8sToTes_defaultFilerImage/executor_01.json"), V1Job.class));
+        }
+        if (withPods) {
+            taskBuilder.addPodList(this.gson.fromJson(TestUtils.getFileContentFromResources("fromK8sToTes_defaultFilerImage/taskmaster_pods.json"), V1PodList.class).getItems());
+            taskBuilder.addPodList(this.gson.fromJson(TestUtils.getFileContentFromResources("fromK8sToTes_defaultFilerImage/executor_pods.json"), V1PodList.class).getItems());
+        }
+        return taskBuilder;
+    }
+
+    private TesTask prepareBaseExpectedTask() throws IOException {
+        return this.objectMapper.readValue(TestUtils.getFileContentFromResources("fromK8sToTes_defaultFilerImage/task.json"), TesTask.class);
+    }
+
+    @Test
+    public void fromK8sToTask_complete() throws IOException {
+        TaskBuilder taskBuilder = this.prepareBaseTaskBuider(true, false);
+        taskBuilder.getTask().getTaskmaster().getJob().getStatus().succeeded(1);
+        taskBuilder.getTask().getLastExecutor().get().getJob().getStatus().succeeded(1);
+        TesTask expectedTask = this.prepareBaseExpectedTask();
+        expectedTask.setState(TesState.COMPLETE);
+        TesTask outputTask = this.converter.fromK8sJobsToTesTaskMinimal(taskBuilder.getTask(), false);
+        assertThat(outputTask, CoreMatchers.is(expectedTask));
+    }
+
+    @Test
+    public void fromK8sToTask_list() throws IOException {
+        TaskBuilder taskBuilder = this.prepareBaseTaskBuider(true, false);
+        taskBuilder.getTask().getTaskmaster().getJob().getStatus().succeeded(1);
+        taskBuilder.getTask().getLastExecutor().get().getJob().getStatus().succeeded(1);
+        TesTask expectedTask = this.prepareBaseExpectedTask();
+        expectedTask.setState(TesState.COMPLETE);
+        expectedTask.setLogs(null);
+        TesTask outputTask = this.converter.fromK8sJobsToTesTaskMinimal(taskBuilder.getTask(), true);
+        assertThat(outputTask, CoreMatchers.is(expectedTask));
+    }
+
+    @Test
+    public void fromK8sToTask_cancelled() throws IOException {
+        //only taskmaster job matters
+        TaskBuilder taskBuilder = this.prepareBaseTaskBuider(false, false);
+        taskBuilder.getTask().getTaskmaster().getJob().getMetadata().getLabels().putIfAbsent(LABEL_TASKSTATE_KEY, LABEL_TASKSTATE_VALUE_CANC);
+        TesTask expectedTask = this.prepareBaseExpectedTask();
+        expectedTask.setState(TesState.CANCELED);
+        TesTask outputTask = this.converter.fromK8sJobsToTesTaskMinimal(taskBuilder.getTask(), false);
+        assertThat(outputTask, CoreMatchers.is(expectedTask));
+    }
+
+    @Test
+    public void fromK8sToTask_running() throws IOException {
+        TaskBuilder taskBuilder = this.prepareBaseTaskBuider(true, false);
+        taskBuilder.getTask().getTaskmaster().getJob().getStatus().active(1);
+        TesTask expectedTask = this.prepareBaseExpectedTask();
+        expectedTask.setState(TesState.RUNNING);
+        TesTask outputTask = this.converter.fromK8sJobsToTesTaskMinimal(taskBuilder.getTask(), false);
+        assertThat(outputTask, CoreMatchers.is(expectedTask));
+    }
+
+    @Test
+    public void fromK8sToTask_queued_taskmaster() throws IOException {
+        TaskBuilder taskBuilder = this.prepareBaseTaskBuider(false, true);
+        taskBuilder.getTask().getTaskmaster().getFirstPod().getStatus().setPhase(K8sConstants.PodPhase.PENDING.getCode());
+        TesTask expectedTask = this.prepareBaseExpectedTask();
+        expectedTask.setState(TesState.QUEUED);
+        TesTask outputTask = this.converter.fromK8sJobsToTesTaskMinimal(taskBuilder.getTask(), false);
+        assertThat(outputTask, CoreMatchers.is(expectedTask));
+    }
+
+    @Test
+    public void fromK8sToTask_queued_executor() throws IOException {
+        TaskBuilder taskBuilder = this.prepareBaseTaskBuider(true, true);
+        taskBuilder.getTask().getLastExecutor().get().getFirstPod().getStatus().setPhase(K8sConstants.PodPhase.PENDING.getCode());
+        TesTask expectedTask = this.prepareBaseExpectedTask();
+        expectedTask.setState(TesState.QUEUED);
+        TesTask outputTask = this.converter.fromK8sJobsToTesTaskMinimal(taskBuilder.getTask(), false);
+        assertThat(outputTask, CoreMatchers.is(expectedTask));
+    }
+
+    @Test
+    public void fromK8sToTask_system_error_no_state() throws IOException {
+        TaskBuilder taskBuilder = this.prepareBaseTaskBuider(false, false);
+        TesTask expectedTask = this.prepareBaseExpectedTask();
+        expectedTask.setState(TesState.SYSTEM_ERROR);
+        TesTask outputTask = this.converter.fromK8sJobsToTesTaskMinimal(taskBuilder.getTask(), false);
+        assertThat(outputTask, CoreMatchers.is(expectedTask));
+    }
+
+    @Test
+    public void fromK8sToTask_system_error_no_executors() throws IOException {
+        TaskBuilder taskBuilder = this.prepareBaseTaskBuider(false, false);
+        taskBuilder.getTask().getTaskmaster().getJob().getStatus().succeeded(1);
+        TesTask expectedTask = this.prepareBaseExpectedTask();
+        expectedTask.setState(TesState.SYSTEM_ERROR);
+        TesTask outputTask = this.converter.fromK8sJobsToTesTaskMinimal(taskBuilder.getTask(), false);
+        assertThat(outputTask, CoreMatchers.is(expectedTask));
+    }
+
+    @Test
+    public void fromK8sToTask_system_error_mismatch() throws IOException {
+        TaskBuilder taskBuilder = this.prepareBaseTaskBuider(true, false);
+        taskBuilder.getTask().getTaskmaster().getJob().getStatus().succeeded(1);
+        taskBuilder.getTask().getLastExecutor().get().getJob().getStatus().active(1);
+        TesTask expectedTask = this.prepareBaseExpectedTask();
+        expectedTask.setState(TesState.SYSTEM_ERROR);
+        TesTask outputTask = this.converter.fromK8sJobsToTesTaskMinimal(taskBuilder.getTask(), false);
+        assertThat(outputTask, CoreMatchers.is(expectedTask));
+    }
+
+    @Test
+    public void fromK8sToTask_system_error_filer() throws IOException {
+        TaskBuilder taskBuilder = this.prepareBaseTaskBuider(true, false)
+        .addJob(new V1Job().metadata(new V1ObjectMeta().putLabelsItem("aa", "vv")).status(new V1JobStatus().failed(2)));
+        taskBuilder.getTask().getTaskmaster().getJob().getStatus().succeeded(1);
+        taskBuilder.getTask().getLastExecutor().get().getJob().getStatus().succeeded(1);
+        TesTask expectedTask = this.prepareBaseExpectedTask();
+        expectedTask.setState(TesState.SYSTEM_ERROR);
+        TesTask outputTask = this.converter.fromK8sJobsToTesTaskMinimal(taskBuilder.getTask(), false);
+        assertThat(outputTask, CoreMatchers.is(expectedTask));
+    }
+
+    @Test
+    public void fromK8sToTask_executor_error() throws IOException {
+        TaskBuilder taskBuilder = this.prepareBaseTaskBuider(true, false);
+        taskBuilder.getTask().getTaskmaster().getJob().getStatus().succeeded(1);
+        taskBuilder.getTask().getLastExecutor().get().getJob().getStatus().failed(1);
+        TesTask expectedTask = this.prepareBaseExpectedTask();
+        expectedTask.setState(TesState.EXECUTOR_ERROR);
+        TesTask outputTask = this.converter.fromK8sJobsToTesTaskMinimal(taskBuilder.getTask(), false);
+        assertThat(outputTask, CoreMatchers.is(expectedTask));
+    }
+
+    @Test
+    public void fromK8sToTask_initializing() throws IOException {
+        TaskBuilder taskBuilder = this.prepareBaseTaskBuider(false, false);
+        taskBuilder.getTask().getTaskmaster().getJob().getStatus().active(1);
+        TesTask expectedTask = this.prepareBaseExpectedTask();
+        expectedTask.setState(TesState.INITIALIZING);
+        TesTask outputTask = this.converter.fromK8sJobsToTesTaskMinimal(taskBuilder.getTask(), false);
+        assertThat(outputTask, CoreMatchers.is(expectedTask));
+    }
+
+
+}

--- a/src/test/java/uk/ac/ebi/tsc/tesk/util/component/TesKubernetesConverterMinimalTest.java
+++ b/src/test/java/uk/ac/ebi/tsc/tesk/util/component/TesKubernetesConverterMinimalTest.java
@@ -57,6 +57,7 @@ import static uk.ac.ebi.tsc.tesk.util.constant.Constants.LABEL_TASKSTATE_VALUE_C
         properties = {"tesk.api.taskmaster.image-name = task-minimal-image-name",
                 "tesk.api.taskmaster.image-version = task-minimal-image-version",
                 "tesk.api.taskmaster.filer-image-version = task-minimal-filer-image-version",
+                "tesk.api.taskmaster.filer-image-name = task-minimal-filer-image-name",
                 "tesk.api.k8s.namespace = test-namespace"})
 @EnableConfigurationProperties(TaskmasterEnvProperties.class)
 public class TesKubernetesConverterMinimalTest {

--- a/src/test/java/uk/ac/ebi/tsc/tesk/util/component/TesKubernetesConverterTest.java
+++ b/src/test/java/uk/ac/ebi/tsc/tesk/util/component/TesKubernetesConverterTest.java
@@ -53,6 +53,7 @@ import static uk.ac.ebi.tsc.tesk.util.constant.Constants.LABEL_TASKSTATE_VALUE_C
         properties = {"tesk.api.taskmaster.image-name = task-full-image-name",
                 "tesk.api.taskmaster.image-version = task-full-image-version",
                 "tesk.api.taskmaster.filer-image-version = task-full-filer-image-version",
+                "tesk.api.taskmaster.filer-image-name = task-full-filer-image-name",
                 "tesk.api.taskmaster.ftp.secret-name = secretstorage",
                 "tesk.api.taskmaster.service-account-name = custom-service-account",
                 "tesk.api.taskmaster.debug = true",
@@ -128,6 +129,8 @@ public class TesKubernetesConverterTest {
         assertEquals(outputJob.getSpec().getTemplate().getSpec().getServiceAccountName(), "custom-service-account");
         assertEquals(outputJob.getSpec().getTemplate().getSpec().getContainers().get(0).getArgs().get(0), "$(JSON_INPUT)");
         assertEquals(outputJob.getSpec().getTemplate().getSpec().getContainers().get(0).getArgs().get(2), "default");
+        assertEquals(outputJob.getSpec().getTemplate().getSpec().getContainers().get(0).getArgs().get(4), "task-full-filer-image-version");
+        assertEquals(outputJob.getSpec().getTemplate().getSpec().getContainers().get(0).getArgs().get(6), "task-full-filer-image-name");
         assertEquals(outputJob.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(), "task-full-image-name:task-full-image-version");
         assertEquals(outputJob.getSpec().getTemplate().getSpec().getRestartPolicy(), "Never");
 

--- a/src/test/resources/fromK8sToTes_defaultFilerImage/executor_00.json
+++ b/src/test/resources/fromK8sToTes_defaultFilerImage/executor_00.json
@@ -1,0 +1,20 @@
+{
+  "metadata": {
+    "labels": {
+      "executor-no": "0",
+      "job-type": "executor",
+      "taskmaster-name": "task-9ef9856b"
+    },
+    "name": "task-9ef9856b-ex-00"
+  },
+  "spec": {
+    "selector": {
+      "matchLabels": {
+        "controller-uid": "3f396352-64b4-11e8-a06f-fa163ecf0042"
+      }
+    }
+  },
+  "status": {
+
+  }
+}

--- a/src/test/resources/fromK8sToTes_defaultFilerImage/executor_01.json
+++ b/src/test/resources/fromK8sToTes_defaultFilerImage/executor_01.json
@@ -1,0 +1,20 @@
+{
+  "metadata": {
+    "labels": {
+      "executor-no": "1",
+      "job-type": "executor",
+      "taskmaster-name": "task-9ef9856b"
+    },
+    "name": "task-9ef9856b-ex-01"
+  },
+  "spec": {
+    "selector": {
+      "matchLabels": {
+        "controller-uid": "3f396352-64b4-11e8-a06f-fa163ecf0099"
+      }
+    }
+  },
+  "status": {
+
+  }
+}

--- a/src/test/resources/fromK8sToTes_defaultFilerImage/executor_pods.json
+++ b/src/test/resources/fromK8sToTes_defaultFilerImage/executor_pods.json
@@ -1,0 +1,24 @@
+{
+  "items": [
+    {
+      "metadata": {
+        "labels": {
+          "controller-uid": "3f396352-64b4-11e8-a06f-fa163ecf0042"
+        }
+      },
+      "status": {
+        "phase": "anything"
+      }
+    },
+    {
+      "metadata": {
+        "labels": {
+          "controller-uid": "3f396352-64b4-11e8-a06f-fa163ecf0099"
+        }
+      },
+      "status": {
+        "phase": "anything"
+      }
+    }
+  ]
+}

--- a/src/test/resources/fromK8sToTes_defaultFilerImage/task.json
+++ b/src/test/resources/fromK8sToTes_defaultFilerImage/task.json
@@ -1,0 +1,12 @@
+{
+  "id": "task-9ef9856b",
+  "state": "?",
+  "logs": [
+    {
+      "metadata": {
+        "GROUP_NAME": "TEST_GROUP",
+        "USER_ID": "TEST_USER"
+      }
+    }
+  ]
+}

--- a/src/test/resources/fromK8sToTes_defaultFilerImage/taskmaster.json
+++ b/src/test/resources/fromK8sToTes_defaultFilerImage/taskmaster.json
@@ -1,0 +1,20 @@
+{
+  "metadata": {
+    "labels": {
+      "creator-group-name": "TEST_GROUP",
+      "creator-user-id": "TEST_USER",
+      "job-type": "taskmaster"
+    },
+    "name": "task-9ef9856b"
+  },
+  "spec": {
+    "selector": {
+      "matchLabels": {
+        "controller-uid": "34a36c28-64b4-11e8-a06f-fa163ecf0042"
+      }
+    }
+  },
+  "status": {
+
+  }
+}

--- a/src/test/resources/fromK8sToTes_defaultFilerImage/taskmaster_pods.json
+++ b/src/test/resources/fromK8sToTes_defaultFilerImage/taskmaster_pods.json
@@ -1,0 +1,14 @@
+{
+  "items": [
+    {
+      "metadata": {
+        "labels": {
+          "controller-uid": "34a36c28-64b4-11e8-a06f-fa163ecf0042"
+        }
+      },
+      "status": {
+        "phase": "anything"
+      }
+    }
+  ]
+}

--- a/src/test/resources/fromTesToK8s/job.json
+++ b/src/test/resources/fromTesToK8s/job.json
@@ -28,6 +28,8 @@
               "default",
               "-fv",
               "task-full-filer-image-version",
+              "-fn",
+              "task-full-filer-image-name",
               "-d"
             ],
             "env": [

--- a/src/test/resources/fromTesToK8s_defaultFilerImage/job.json
+++ b/src/test/resources/fromTesToK8s_defaultFilerImage/job.json
@@ -1,0 +1,63 @@
+{
+  "apiVersion": "batch/v1",
+  "kind": "Job",
+  "metadata": {
+    "annotations": {
+      "json-input": "{\"name\":\"taskFull\",\"description\":\"whatever\",\"inputs\":[{\"name\":\"infile1\",\"description\":\"aa bbb\",\"url\":\"/path1/to/input_file.json\",\"path\":\"/tes/volumes/input.json\",\"type\":\"FILE\"},{\"url\":\"/path2/to/input\",\"path\":\"/tes/volumes/input\",\"type\":\"DIRECTORY\"},{\"path\":\"/container/input/other.txt\",\"type\":\"FILE\",\"content\":\"aaabbbcccddd\"}],\"outputs\":[{\"url\":\"/path/to/output_file.txt\",\"path\":\"/tes/output.txt\",\"type\":\"FILE\"},{\"url\":\"/path/to/output\",\"path\":\"/outputs/output\",\"type\":\"DIRECTORY\"}],\"resources\":{\"cpu_cores\":4},\"executors\":[{\"image\":\"alpine\",\"command\":[\"echo\",\"hello world\"],\"stdout\":\"/tmp/stdout\"},{\"image\":\"alpine\",\"command\":[\"sh\",\"-c\",\"md5sum $src\"],\"workdir\":\"/starthere\",\"stdout\":\"/opt/funnel/outputs/stdout-0\",\"stderr\":\"/opt/funnel/outputs/stderr-0\",\"env\":{\"src\":\"/container/input/other.txt\",\"sth\":\"sthElse\"}}],\"volumes\":[\"/tmp/tmp1\",\"/tmp/tmp2\"],\"tags\":{\"project\":\"important\",\"author\":\"janedoe\"}}"
+    },
+    "labels": {
+      "job-type": "taskmaster",
+      "creator-user-id": "test-user-id",
+      "creator-group-name": "ABC"
+    },
+    "name": "task-98605447"
+  },
+  "spec": {
+    "template": {
+      "metadata": {
+        "name": "task-98605447"
+      },
+      "spec": {
+        "serviceAccountName": "default",
+        "containers": [
+          {
+            "args": [
+              "$(JSON_INPUT)", "-n", "test-namespace", "-fv", "v0.4"
+            ],
+            "env": [
+              {
+                "name": "JSON_INPUT",
+                "value": "{\"outputs\":[{\"url\":\"/path/to/output_file.txt\",\"path\":\"/tes/output.txt\",\"type\":\"FILE\"},{\"url\":\"/path/to/output\",\"path\":\"/outputs/output\",\"type\":\"DIRECTORY\"}],\"inputs\":[{\"name\":\"infile1\",\"description\":\"aa bbb\",\"url\":\"/path1/to/input_file.json\",\"path\":\"/tes/volumes/input.json\",\"type\":\"FILE\"},{\"url\":\"/path2/to/input\",\"path\":\"/tes/volumes/input\",\"type\":\"DIRECTORY\"},{\"path\":\"/container/input/other.txt\",\"type\":\"FILE\",\"content\":\"aaabbbcccddd\"}],\"volumes\":[\"/tmp/tmp1\",\"/tmp/tmp2\"],\"executors\":[{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"annotations\":{\"tes-task-name\":\"taskFull\"},\"labels\":{\"job-type\":\"executor\",\"taskmaster-name\":\"task-35605447\",\"executor-no\":\"0\"},\"name\":\"task-35605447-ex-00\"},\"spec\":{\"template\":{\"metadata\":{\"name\":\"task-35605447-ex-00\"},\"spec\":{\"containers\":[{\"args\":[\"echo\",\"hello world\"],\"command\":[],\"image\":\"alpine\",\"name\":\"task-35605447-ex-00\",\"resources\":{\"requests\":{\"cpu\":\"4\"}}}],\"restartPolicy\":\"Never\"}}}},{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"annotations\":{\"tes-task-name\":\"taskFull\"},\"labels\":{\"job-type\":\"executor\",\"taskmaster-name\":\"task-35605447\",\"executor-no\":\"1\"},\"name\":\"task-35605447-ex-01\"},\"spec\":{\"template\":{\"metadata\":{\"name\":\"task-35605447-ex-01\"},\"spec\":{\"containers\":[{\"args\":[\"sh\",\"-c\",\"md5sum $src\"],\"command\":[],\"env\":[{\"name\":\"src\",\"value\":\"/container/input/other.txt\"},{\"name\":\"sth\",\"value\":\"sthElse\"}],\"image\":\"alpine\",\"name\":\"task-35605447-ex-01\",\"resources\":{\"requests\":{\"cpu\":\"4\"}},\"workingDir\":\"/starthere\"}],\"restartPolicy\":\"Never\"}}}}],\"resources\":{}}"
+              }
+            ],
+            "image": "task-minimal-image-name:task-minimal-image-version",
+            "name": "task-98605447",
+            "volumeMounts": [
+              {
+                "name": "podinfo",
+                "mountPath": "/podinfo",
+                "readOnly": true
+              }
+            ]
+          }
+        ],
+        "volumes": [
+          {
+            "name": "podinfo",
+            "downwardAPI": {
+              "items": [
+                {
+                  "path": "labels",
+                  "fieldRef": {
+                    "fieldPath": "metadata.labels"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "restartPolicy": "Never"
+      }
+    }
+  }
+}

--- a/src/test/resources/fromTesToK8s_defaultFilerImage/task.json
+++ b/src/test/resources/fromTesToK8s_defaultFilerImage/task.json
@@ -1,0 +1,11 @@
+{
+  "executors": [
+    {
+      "image": "ubuntu",
+      "command": [
+        "echo",
+        "hello world"
+      ]
+    }
+  ]
+}

--- a/src/test/resources/fromTesToK8s_defaultFilerImage/taskmaster_param.json
+++ b/src/test/resources/fromTesToK8s_defaultFilerImage/taskmaster_param.json
@@ -1,0 +1,50 @@
+{
+  "outputs": [
+  ],
+  "inputs": [
+  ],
+  "volumes": [
+  ],
+  "executors": [
+    {
+      "apiVersion": "batch/v1",
+      "kind": "Job",
+      "metadata": {
+        "annotations": {
+        },
+        "labels": {
+          "job-type": "executor",
+          "taskmaster-name": "task-98605447",
+          "executor-no": "0",
+          "creator-user-id": "test-user-id"
+        },
+        "name": "task-98605447-ex-00"
+      },
+      "spec": {
+        "template": {
+          "metadata": {
+            "name": "task-98605447-ex-00"
+          },
+          "spec": {
+            "containers": [
+              {
+                "command": [
+                  "echo",
+                  "hello world"
+                ],
+                "image": "ubuntu",
+                "name": "task-98605447-ex-00",
+                "resources": {
+                }
+              }
+            ],
+            "restartPolicy": "Never"
+          }
+        }
+      }
+    }
+  ],
+  "resources": {
+    "disk_gb": 0.1
+  }
+}

--- a/src/test/resources/fromTesToK8s_minimal/job.json
+++ b/src/test/resources/fromTesToK8s_minimal/job.json
@@ -22,7 +22,7 @@
         "containers": [
           {
             "args": [
-              "$(JSON_INPUT)", "-n", "test-namespace", "-fv", "task-minimal-filer-image-version"
+              "$(JSON_INPUT)", "-n", "test-namespace", "-fv", "task-minimal-filer-image-version", "-fn", "task-minimal-filer-image-name"
             ],
             "env": [
               {


### PR DESCRIPTION
 Using TESK_API_TASKMASTER_FILER_IMAGE_NAME environment variable, now it is possible to change the default filer image name.