### PR TITLE
Quick and dirty fix to scientific notation problem

### DIFF
--- a/src/main/java/uk/ac/ebi/tsc/tesk/util/component/TesKubernetesConverter.java
+++ b/src/main/java/uk/ac/ebi/tsc/tesk/util/component/TesKubernetesConverter.java
@@ -143,7 +143,11 @@ public class TesKubernetesConverter {
         }
         container.setWorkingDir(executor.getWorkdir());
         Optional.ofNullable(resources).map(TesResources::getCpuCores).ifPresent(cpuCores -> container.getResources().putRequestsItem(RESOURCE_CPU_KEY, cpuCores.toString()));
-        Optional.ofNullable(resources).map(TesResources::getRamGb).ifPresent(ramGb -> container.getResources().putRequestsItem(RESOURCE_MEM_KEY, ramGb.toString() + RESOURCE_MEM_UNIT));
+        Optional.ofNullable(resources).map(TesResources::getRamGb).ifPresent(ramGb -> container.getResources().putRequestsItem(RESOURCE_MEM_KEY, (ramGb>0.004 ? String.format("%.3f", ramGb) : "0.004" ) + RESOURCE_MEM_UNIT));
+        //
+        // The minimum memory is set arbitrarly to ~4MB, TODO improve this, so it fails
+        // instead back to the user user or something like this
+        //
         return job;
     }
 

--- a/src/test/java/uk/ac/ebi/tsc/tesk/util/component/TesKubernetesConverterTest.java
+++ b/src/test/java/uk/ac/ebi/tsc/tesk/util/component/TesKubernetesConverterTest.java
@@ -161,7 +161,7 @@ public class TesKubernetesConverterTest {
 
         taskMasterInputJson.extractingJsonPathArrayValue("executors[*].spec.template.spec.restartPolicy").containsOnly("Never").hasSize(2);
         taskMasterInputJson.extractingJsonPathArrayValue("executors[*].spec.template.spec.containers[0].resources.requests.cpu").containsOnly("4").hasSize(2);
-        taskMasterInputJson.extractingJsonPathArrayValue("executors[*].spec.template.spec.containers[0].resources.requests.memory").containsOnly("15.0G").hasSize(2);
+        taskMasterInputJson.extractingJsonPathArrayValue("executors[*].spec.template.spec.containers[0].resources.requests.memory").containsOnly("15.000G").hasSize(2);
 
         taskMasterInputJson.extractingJsonPathMapValue("executors[0].spec.template.spec.containers[0]").containsOnlyKeys("name", "image", "command", "resources", "volumeMounts");
         taskMasterInputJson.extractingJsonPathMapValue("executors[1].spec.template.spec.containers[0]").containsOnlyKeys("name", "image", "command", "resources", "workingDir", "env", "volumeMounts");

--- a/src/test/resources/fromTesToK8s/taskmaster_param.json
+++ b/src/test/resources/fromTesToK8s/taskmaster_param.json
@@ -68,7 +68,7 @@
                 "resources": {
                   "requests": {
                     "cpu": "4",
-                    "memory": "15.0G"
+                    "memory": "15.000G"
                   }
                 },
                 "volumeMounts": [
@@ -136,7 +136,7 @@
                 "resources": {
                   "requests": {
                     "cpu": "4",
-                    "memory": "15.0G"
+                    "memory": "15.000G"
                   }
                 },
                 "workingDir": "/starthere",


### PR DESCRIPTION
Quick and dirty fix, to the scientific notation and too memory low problems.

It took a while to find the spot, but it fixes both bugs. Kubernetes does not like in the memory specification of the Pod, the scientific notation format JAVA uses. This code could be improved by, using the API to get the current minimum and maximum memories, convert the memory value to the memory unit that suits better, i.e.: 0.1 GiB should be ~100MiB.