### PR TITLE
Trs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.1.RELEASE</version>
+        <version>2.0.3.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/src/integration-test/java/uk/ac/ebi/tsc/tesk/trs/TrsToolClientIT.java
+++ b/src/integration-test/java/uk/ac/ebi/tsc/tesk/trs/TrsToolClientIT.java
@@ -1,0 +1,115 @@
+package uk.ac.ebi.tsc.tesk.trs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.client.MockRestServiceServer;
+import uk.ac.ebi.tsc.tesk.trs.model.ImageData;
+import uk.ac.ebi.tsc.tesk.trs.model.ImageType;
+import uk.ac.ebi.tsc.tesk.trs.model.ToolVersion;
+
+import javax.annotation.PostConstruct;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * @author aniewielska
+ * @since 31/03/2021
+ */
+@RunWith(SpringRunner.class)
+@RestClientTest(TrsToolClient.class)
+@TestPropertySource(properties = {"tesk.api.trs.urlPattern=https://{host}/trs/{id}/versions/{version}",
+        "tesk.api.trs.uriPattern=trs://{host}/trs-id/{id}/{version}"})
+public class TrsToolClientIT {
+
+    @Autowired
+    private TrsToolClient subject;
+    @Autowired
+    private MockRestServiceServer server;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @TestConfiguration
+    static class Configuration {
+        @Bean
+        public TrsProperties trsProperties() {
+            return new TrsProperties();
+        }
+    }
+
+    private String detailsStringWithDocker;
+    private String detailsStringWithoutDocker;
+
+    @PostConstruct
+    public void setup() throws Exception {
+        ToolVersion toolVersion = new ToolVersion();
+        ImageData imageData1 = new ImageData();
+        imageData1.setImageType(ImageType.Docker);
+        imageData1.setImageName("ubuntu:latest");
+        toolVersion.getImages().add(imageData1);
+        ImageData imageData2 = new ImageData();
+        imageData2.setImageType(ImageType.Conda);
+        imageData2.setImageName("sthElse");
+        toolVersion.getImages().add(imageData2);
+        detailsStringWithDocker =
+                objectMapper.writeValueAsString(toolVersion);
+        toolVersion.getImages().remove(0);
+        detailsStringWithoutDocker =
+                objectMapper.writeValueAsString(toolVersion);
+    }
+
+    @Before
+    public void setUp() {
+        this.server.reset();
+    }
+
+    @Test
+    public void getDockerImageForToolVersionURI_success() {
+        this.server.expect(requestTo("https://trsHost/trs/toolId/versions/toolVersion"))
+                .andRespond(withSuccess(detailsStringWithDocker, MediaType.APPLICATION_JSON));
+        String result = subject.getDockerImageForToolVersionURI("trs://trsHost/trs-id/toolId/toolVersion");
+        assertThat(result, is("ubuntu:latest"));
+    }
+
+    @Test
+    public void getDockerImageForToolVersionURI_wrongUri() {
+        String result = subject.getDockerImageForToolVersionURI("sth");
+        assertThat(result, is("sth"));
+    }
+
+    @Test
+    public void getDockerImageForToolVersionURI_noDocker() {
+        this.server.expect(requestTo("https://trsHost/trs/toolId2/versions/toolVersion2"))
+                .andRespond(withSuccess(detailsStringWithoutDocker, MediaType.APPLICATION_JSON));
+        String result = subject.getDockerImageForToolVersionURI("trs://trsHost/trs-id/toolId2/toolVersion2");
+        assertThat(result, is("trs://trsHost/trs-id/toolId2/toolVersion2"));
+    }
+
+    @Test
+    public void getDockerImageForToolVersion_success() {
+        this.server.expect(requestTo("https://trsHost/trs/toolId/versions/toolVersion"))
+                .andRespond(withSuccess(detailsStringWithDocker, MediaType.APPLICATION_JSON));
+        Optional<String> result = subject.getDockerImageForToolVersion("trsHost", "toolId", "toolVersion");
+        assertThat(result.get(), is("ubuntu:latest"));
+    }
+
+    @Test
+    public void getDockerImageForToolVersion_noDocker() {
+        this.server.expect(requestTo("https://trsHost/trs/toolId2/versions/toolVersion2"))
+                .andRespond(withSuccess(detailsStringWithoutDocker, MediaType.APPLICATION_JSON));
+        Optional<String> result = subject.getDockerImageForToolVersion("trsHost", "toolId2", "toolVersion2");
+        assertThat(result, is(Optional.empty()));
+    }
+}

--- a/src/main/java/uk/ac/ebi/tsc/tesk/trs/TrsProperties.java
+++ b/src/main/java/uk/ac/ebi/tsc/tesk/trs/TrsProperties.java
@@ -1,0 +1,18 @@
+package uk.ac.ebi.tsc.tesk.trs;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author aniewielska
+ * @since 22/09/2020
+ */
+@Configuration
+@ConfigurationProperties(prefix = "tesk.api.trs")
+@Data
+public class TrsProperties {
+    private String uriPattern;
+    private String urlPattern;
+}
+

--- a/src/main/java/uk/ac/ebi/tsc/tesk/trs/TrsToolClient.java
+++ b/src/main/java/uk/ac/ebi/tsc/tesk/trs/TrsToolClient.java
@@ -1,0 +1,73 @@
+package uk.ac.ebi.tsc.tesk.trs;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.client.RestTemplate;
+import uk.ac.ebi.tsc.tesk.trs.model.ImageData;
+import uk.ac.ebi.tsc.tesk.trs.model.ImageType;
+import uk.ac.ebi.tsc.tesk.trs.model.ToolVersion;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * @author aniewielska
+ * @since 22/09/2020
+ */
+@Slf4j
+@Service
+public class TrsToolClient {
+    private final RestTemplate restTemplate;
+    private final TrsProperties properties;
+
+    public TrsToolClient(RestTemplateBuilder restTemplateBuilder, TrsProperties properties) {
+        this.restTemplate = restTemplateBuilder.build();
+        this.properties = properties;
+    }
+
+    public String getDockerImageForToolVersionURI(String trsURI) {
+        String[] toolCoordinates = new String[3];
+        if (translateTrsURI(trsURI, toolCoordinates)) {
+            return getDockerImageForToolVersion(toolCoordinates[0], toolCoordinates[1], toolCoordinates[2]).orElse(trsURI);
+        }
+        return trsURI;
+    }
+
+    Optional<String> getDockerImageForToolVersion(String trsHost, String toolId, String toolVersion) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
+            //Why do I need to emulate the browser is not quite clear.. TBC
+            headers.add("user-agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.99 Safari/537.36");
+            HttpEntity entity = new HttpEntity(headers);
+            ResponseEntity<ToolVersion> response = restTemplate.exchange(properties.getUrlPattern(), HttpMethod.GET, entity, ToolVersion.class, trsHost, toolId, toolVersion);
+            if (response.getStatusCode().is2xxSuccessful()) {
+                ToolVersion version = response.getBody();
+                if (response.getBody() != null && !version.getImages().isEmpty()) {
+                    return version.getImages().stream().filter(imageData -> imageData.getImageType() == ImageType.Docker).findFirst().map(ImageData::getImageName);
+                }
+            }
+        } catch (Exception e) {
+            log.info("Error {} retrieving TRS Version {} {} {}", e, trsHost, toolId, toolVersion);
+        }
+        return Optional.empty();
+
+    }
+
+    boolean translateTrsURI(String trsURI, String[] result) {
+        AntPathMatcher matcher = new AntPathMatcher();
+        if (matcher.match(properties.getUriPattern(), trsURI)) {
+            Map<String, String> variables = matcher.extractUriTemplateVariables(properties.getUriPattern(), trsURI);
+            result[0] = variables.get("host");
+            result[1] = variables.get("id");
+            result[2] = variables.get("version");
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/uk/ac/ebi/tsc/tesk/trs/model/ImageData.java
+++ b/src/main/java/uk/ac/ebi/tsc/tesk/trs/model/ImageData.java
@@ -1,0 +1,18 @@
+package uk.ac.ebi.tsc.tesk.trs.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+/**
+ * @author aniewielska
+ * @since 22/09/2020
+ */
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ImageData {
+    private String imageName;
+    private ImageType imageType;
+}

--- a/src/main/java/uk/ac/ebi/tsc/tesk/trs/model/ImageType.java
+++ b/src/main/java/uk/ac/ebi/tsc/tesk/trs/model/ImageType.java
@@ -1,0 +1,9 @@
+package uk.ac.ebi.tsc.tesk.trs.model;
+
+/**
+ * @author aniewielska
+ * @since 22/09/2020
+ */
+public enum ImageType {
+    Docker, Singularity, Conda
+}

--- a/src/main/java/uk/ac/ebi/tsc/tesk/trs/model/ToolVersion.java
+++ b/src/main/java/uk/ac/ebi/tsc/tesk/trs/model/ToolVersion.java
@@ -1,0 +1,19 @@
+package uk.ac.ebi.tsc.tesk.trs.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author aniewielska
+ * @since 22/09/2020
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ToolVersion {
+    private String id;
+    private String url;
+    private List<ImageData> images = new ArrayList<>();
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -57,3 +57,6 @@ tesk.api.swagger-oauth.token-endpoint=https://login.elixir-czech.org/oidc/token
 tesk.api.swagger-oauth.client-id=changeme
 tesk.api.swagger-oauth.client-secret=changeme
 tesk.api.swagger-oauth.scopes=openid:Standard openid,${tesk.api.authorisation.groups-claim}:Access to groups membership,profile:Identity info about user,email:Email
+
+tesk.api.trs.uriPattern=trs://{host}/{id}/versions/{version}
+tesk.api.trs.urlPattern=https://{host}/ga4gh/trs/v2/tools/{id}/versions/{version}

--- a/src/test/java/uk/ac/ebi/tsc/tesk/trs/TrsToolClientTest.java
+++ b/src/test/java/uk/ac/ebi/tsc/tesk/trs/TrsToolClientTest.java
@@ -1,0 +1,61 @@
+package uk.ac.ebi.tsc.tesk.trs;
+
+import lombok.AllArgsConstructor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author aniewielska
+ * @since 30/03/2021
+ */
+@AllArgsConstructor
+@RunWith(Parameterized.class)
+public class TrsToolClientTest {
+
+
+    private final String uriPattern;
+    private final String uri;
+    private final boolean expectedMatch;
+    private final String host;
+    private final String id;
+    private final String version;
+
+    private final static String URI_PATTERN_1 = "trs://{host}/{id}/versions/{version}";
+    private final static String URI_PATTERN_2 = "protocol{host}_{id}_{version}";
+
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {URI_PATTERN_1, "trs://example.com/identifier/versions/123", true, "example.com", "identifier", "123"},
+                {URI_PATTERN_1, "trs://example.com/identifier/123", false, "", "", ""},
+                {URI_PATTERN_2, "protocolexample.com_identifier_123", true, "example.com", "identifier", "123"},
+                {URI_PATTERN_2, "protocoexample.com_identifier_123", false, "", "", ""}
+        });
+    }
+
+
+    @Test
+    public void testTranslateTrsURI_match() {
+        String[] results = new String[3];
+        TrsProperties properties = new TrsProperties();
+        properties.setUriPattern(uriPattern);
+        TrsToolClient subject = new TrsToolClient(new RestTemplateBuilder(), properties);
+        boolean match = subject.translateTrsURI(uri, results);
+        assertThat(match, is(expectedMatch));
+        if (expectedMatch) {
+            assertThat(results[0], is(host));
+            assertThat(results[1], is(id));
+            assertThat(results[2], is(version));
+        }
+    }
+
+}

--- a/src/test/java/uk/ac/ebi/tsc/tesk/util/component/TesKubernetesConverterMinimalTest.java
+++ b/src/test/java/uk/ac/ebi/tsc/tesk/util/component/TesKubernetesConverterMinimalTest.java
@@ -31,6 +31,7 @@ import uk.ac.ebi.tsc.tesk.config.TaskmasterEnvProperties;
 import uk.ac.ebi.tsc.tesk.config.security.User;
 import uk.ac.ebi.tsc.tesk.model.TesState;
 import uk.ac.ebi.tsc.tesk.model.TesTask;
+import uk.ac.ebi.tsc.tesk.trs.TrsToolClient;
 import uk.ac.ebi.tsc.tesk.util.constant.Constants;
 import uk.ac.ebi.tsc.tesk.util.constant.K8sConstants;
 import uk.ac.ebi.tsc.tesk.util.data.TaskBuilder;
@@ -43,7 +44,11 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static uk.ac.ebi.tsc.tesk.util.constant.Constants.LABEL_TASKSTATE_KEY;
 import static uk.ac.ebi.tsc.tesk.util.constant.Constants.LABEL_TASKSTATE_VALUE_CANC;
 
@@ -59,6 +64,8 @@ public class TesKubernetesConverterMinimalTest {
 
     @MockBean
     private JobNameGenerator jobNameGenerator;
+
+    private TrsToolClient trsToolClient;
 
     @TestConfiguration
     @Import({KubernetesObjectsSupplier.class, GsonConfig.class})
@@ -84,9 +91,10 @@ public class TesKubernetesConverterMinimalTest {
 
     @Before
     public void setUpConverter() {
-
+        trsToolClient = mock(TrsToolClient.class);
+        when(trsToolClient.getDockerImageForToolVersionURI(anyString())).then(returnsFirstArg());
         this.converter = new TesKubernetesConverter(executorTemplateSupplier, taskmasterTemplateSupplier,
-                objectMapper, gson);
+                objectMapper, gson, trsToolClient);
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/tsc/tesk/util/component/TesKubernetesConverterTest.java
+++ b/src/test/java/uk/ac/ebi/tsc/tesk/util/component/TesKubernetesConverterTest.java
@@ -28,6 +28,7 @@ import uk.ac.ebi.tsc.tesk.config.TaskmasterEnvProperties;
 import uk.ac.ebi.tsc.tesk.config.security.User;
 import uk.ac.ebi.tsc.tesk.model.TesState;
 import uk.ac.ebi.tsc.tesk.model.TesTask;
+import uk.ac.ebi.tsc.tesk.trs.TrsToolClient;
 import uk.ac.ebi.tsc.tesk.util.constant.Constants;
 import uk.ac.ebi.tsc.tesk.util.data.TaskBuilder;
 
@@ -39,7 +40,11 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static uk.ac.ebi.tsc.tesk.util.constant.Constants.LABEL_TASKSTATE_KEY;
 import static uk.ac.ebi.tsc.tesk.util.constant.Constants.LABEL_TASKSTATE_VALUE_CANC;
 
@@ -69,6 +74,8 @@ public class TesKubernetesConverterTest {
     @MockBean
     private JobNameGenerator jobNameGenerator;
 
+    private TrsToolClient trsToolClient;
+
     @TestConfiguration
     @Import({KubernetesObjectsSupplier.class, GsonConfig.class})
     static class Configuration {
@@ -93,9 +100,10 @@ public class TesKubernetesConverterTest {
 
     @Before
     public void setUpConverter() {
-
+        trsToolClient = mock(TrsToolClient.class);
+        when(trsToolClient.getDockerImageForToolVersionURI(anyString())).then(returnsFirstArg());
         this.converter = new TesKubernetesConverter(executorTemplateSupplier, taskmasterTemplateSupplier,
-                objectMapper, gson);
+                objectMapper, gson, trsToolClient);
     }
 
     @Test


### PR DESCRIPTION
Support for translation of TRS URIs (configurable) into Docker Images.
The `image` field will support both Docker image and TRS URI.
It will search for `Docker` type in images returned from TRS.